### PR TITLE
FE: Разработка UI-страницы организации в админ-панели

### DIFF
--- a/src/features/admin/organizations/organizations-columns.tsx
+++ b/src/features/admin/organizations/organizations-columns.tsx
@@ -1,0 +1,103 @@
+import { Badge } from "@/components/ui/badge";
+import { type ColumnDef } from "@/components/custom-data-table";
+import type { Organization, OrganizationStatus } from "./organizations.types";
+
+const STATUS_STYLES: Record<OrganizationStatus, string> = {
+  active: "bg-green-500/15 text-green-600 border-green-500/30",
+  inactive: "bg-red-500/15 text-red-600 border-red-500/30",
+};
+
+export const ORGANIZATIONS_COLUMNS: ColumnDef<Organization>[] = [
+  {
+    key: "id",
+    header: "ID",
+    cell: (row) => row.id,
+  },
+  {
+    key: "name",
+    header: "Название организации",
+    cell: (row) => row.name,
+  },
+  {
+    key: "email",
+    header: "Email",
+    cell: (row) => row.email,
+  },
+  {
+    key: "phone",
+    header: "Телефон",
+    cell: (row) => row.phone,
+  },
+  {
+    key: "status",
+    header: "Статус",
+    cell: (row) => (
+      <Badge variant="outline" className={STATUS_STYLES[row.status]}>
+        {row.status === "active" ? "Активна" : "Неактивна"}
+      </Badge>
+    ),
+  },
+  {
+    key: "createdAt",
+    header: "Дата создания",
+    cellClassName: "text-muted-foreground text-sm",
+    cell: (row) => row.createdAt,
+  },
+];
+
+export const MOCK_ORGANIZATIONS: Organization[] = [
+  {
+    id: 1,
+    name: "Русарс",
+    email: "info@rusars.ru",
+    phone: "+7 (495) 123-45-67",
+    status: "active",
+    createdAt: "10:15 15.01.2026",
+    address: "Москва, ул. Ленина, 10",
+  },
+  {
+    id: 2,
+    name: "Олимп",
+    email: "contact@olymp.ru",
+    phone: "+7 (812) 234-56-78",
+    status: "inactive",
+    createdAt: "14:30 20.02.2026",
+    address: "Санкт-Петербург, Невский пр., 25",
+  },
+  {
+    id: 3,
+    name: "Прогресс",
+    email: "hello@progress.ru",
+    phone: "+7 (843) 345-67-89",
+    status: "active",
+    createdAt: "09:45 19.03.2026",
+    address: "Казань, ул. Баумана, 15",
+  },
+  {
+    id: 4,
+    name: "Спартак",
+    email: "info@spartak.ru",
+    phone: "+7 (861) 456-78-90",
+    status: "active",
+    createdAt: "16:20 25.03.2026",
+    address: "Краснодар, ул. Красная, 5",
+  },
+  {
+    id: 5,
+    name: "Динамо",
+    email: "contact@dynamo.ru",
+    phone: "+7 (383) 567-89-01",
+    status: "inactive",
+    createdAt: "11:05 01.04.2026",
+    address: "Новосибирск, пр. Димитрова, 8",
+  },
+  {
+    id: 6,
+    name: "Русарс",
+    email: "support@rusars.ru",
+    phone: "+7 (495) 678-90-12",
+    status: "active",
+    createdAt: "08:30 05.04.2026",
+    address: "Москва, ул. Тверская, 20",
+  },
+];

--- a/src/features/admin/organizations/organizations-page.tsx
+++ b/src/features/admin/organizations/organizations-page.tsx
@@ -1,0 +1,15 @@
+import { CustomDataTable } from "@/components/custom-data-table";
+import { ORGANIZATIONS_COLUMNS, MOCK_ORGANIZATIONS } from "./organizations-columns";
+import { PageHeader } from "@/components/page-header";
+
+export function OrganizationsPage() {
+  return (
+    <div className="container mx-auto pb-12">
+      <PageHeader title="Организации" showBack backTo="/admin" />
+
+      <div className="bg-card rounded-2xl border shadow-sm overflow-hidden">
+        <CustomDataTable columns={ORGANIZATIONS_COLUMNS} data={MOCK_ORGANIZATIONS} />
+      </div>
+    </div>
+  );
+}

--- a/src/features/admin/organizations/organizations.types.ts
+++ b/src/features/admin/organizations/organizations.types.ts
@@ -1,0 +1,11 @@
+export type OrganizationStatus = "active" | "inactive";
+
+export interface Organization {
+  id: number;
+  name: string;
+  email: string;
+  phone: string;
+  status: OrganizationStatus;
+  createdAt: string;
+  address?: string;
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -11,6 +11,7 @@ import {
 import { DashboardPage as AdminDashboardPage } from "@/features/admin/dashboard/dashboard-page";
 import { ComplaintsPage } from "@/features/admin/complaints/complaints-page";
 import { LogsPage } from "@/features/admin/admin-logs/logs-page";
+import { OrganizationsPage } from "@/features/admin/organizations/organizations-page";
 
 // Federation Features
 import { DashboardPage as FederationDashboardPage } from "@/features/federation/dashboard/dashboard-page";
@@ -52,7 +53,7 @@ const router = createBrowserRouter([
       },
       {
         path: "organizations",
-        element: <div>Организации (В разработке)</div>,
+        element: <OrganizationsPage />,
       },
       {
         path: "logs",


### PR DESCRIPTION
Closes #18


## Что сделано:
- ✅ Добавлена страница организаций по пути `/admin/organizations`
- ✅ Реализована таблица с мок-данными
- ✅ Добавлены статусы (активна/неактивна) в виде бейджей
- ✅ Использован компонент CustomDataTable
- ✅ Только UI, без API-интеграции